### PR TITLE
95 rename resources label on control overview

### DIFF
--- a/src/components/control-overview/control-overview-item-instances.js
+++ b/src/components/control-overview/control-overview-item-instances.js
@@ -122,7 +122,7 @@ export function ControlOverviewItemInstances({ instanceData }) {
       <TableContainer>
         <Toolbar variant="dense" className={classes.toolbar}>
           <Typography variant="subtitle2" component="p">
-            Instances
+            Resources
           </Typography>
 
           {filters && filters.length > 1 && (

--- a/src/components/control-overview/control-overview-item-resources.js
+++ b/src/components/control-overview/control-overview-item-resources.js
@@ -23,8 +23,8 @@ import Box from "@material-ui/core/Box";
 import clsx from "clsx";
 import dayjs from "dayjs";
 
-export function ControlOverviewItemInstances({ instanceData }) {
-  const classes = useControlOverviewItemInstancesStyles();
+export function ControlOverviewItemResources({ resourcesData }) {
+  const classes = useControlOverviewItemResourcesStyles();
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [activeFilters, setActiveFilters] = useState([]);
@@ -49,7 +49,7 @@ export function ControlOverviewItemInstances({ instanceData }) {
   };
 
   const filters = useMemo(() => {
-    return instanceData
+    return resourcesData
       .map((instance) => instance.environment)
       .reduce((uniqueFilters, filter) => {
         return uniqueFilters.includes(filter)
@@ -57,19 +57,19 @@ export function ControlOverviewItemInstances({ instanceData }) {
           : [...uniqueFilters, filter];
       }, [])
       .sort();
-  }, [instanceData]);
+  }, [resourcesData]);
 
-  const getInstancesByFilterValues = (instances, filterValues) => {
-    if (filterValues.length < 1) return instances;
+  const getResourcesByFilterValues = (resources, filterValues) => {
+    if (filterValues.length < 1) return resources;
 
-    return instances.filter((instance) =>
+    return resources.filter((instance) =>
       filterValues.includes(instance.environment)
     );
   };
 
-  const getInstancesSortedByLastSeenDate = (instances, sortBy) => {
+  const getResourcesSortedByLastSeenDate = (resources, sortBy) => {
     return [
-      ...instances.sort((a, b) => {
+      ...resources.sort((a, b) => {
         if (sortBy === "asc") {
           return Date.parse(a.lastSeen) - Date.parse(b.lastSeen);
         }
@@ -82,12 +82,12 @@ export function ControlOverviewItemInstances({ instanceData }) {
     ];
   };
 
-  const processedInstanceData = useMemo(() => {
-    return getInstancesByFilterValues(
-      getInstancesSortedByLastSeenDate(instanceData, lastSeenOrder),
+  const processedResourcesData = useMemo(() => {
+    return getResourcesByFilterValues(
+      getResourcesSortedByLastSeenDate(resourcesData, lastSeenOrder),
       activeFilters
     );
-  }, [instanceData, lastSeenOrder, activeFilters]);
+  }, [resourcesData, lastSeenOrder, activeFilters]);
 
   const handleOnSortByLastSeenClick = () => {
     if (lastSeenOrder === "asc") {
@@ -208,7 +208,7 @@ export function ControlOverviewItemInstances({ instanceData }) {
               <TableCell>Resource</TableCell>
               <TableCell>Environment</TableCell>
               <TableCell sortDirection={lastSeenOrder}>
-                {processedInstanceData.length > 1 ? (
+                {processedResourcesData.length > 1 ? (
                   <TableSortLabel
                     active={true}
                     direction={lastSeenOrder}
@@ -234,23 +234,23 @@ export function ControlOverviewItemInstances({ instanceData }) {
           </TableHead>
 
           <TableBody className={classes.tableBody}>
-            {processedInstanceData.map((instance) => {
+            {processedResourcesData.map((resource) => {
               return (
-                <TableRow key={instance.type}>
-                  <TableCell>{instance.type}</TableCell>
-                  <TableCell>{instance.reference}</TableCell>
-                  <TableCell>{instance.environment}</TableCell>
+                <TableRow key={resource.type}>
+                  <TableCell>{resource.type}</TableCell>
+                  <TableCell>{resource.reference}</TableCell>
+                  <TableCell>{resource.environment}</TableCell>
                   <TableCell>
-                    {dayjs(instance.lastSeen).format("MMM D YYYY - h:mm A")}
+                    {dayjs(resource.lastSeen).format("MMM D YYYY - h:mm A")}
                   </TableCell>
                   <TableCell>
                     <span
                       className={clsx(
                         classes.statusLabel,
-                        classes[getStatusLabelClassName(instance.status)]
+                        classes[getStatusLabelClassName(resource.status)]
                       )}
                     >
-                      {instance.status}
+                      {resource.status}
                     </span>
                   </TableCell>
                 </TableRow>
@@ -263,8 +263,8 @@ export function ControlOverviewItemInstances({ instanceData }) {
   );
 }
 
-ControlOverviewItemInstances.propTypes = {
-  instanceData: PropTypes.arrayOf(
+ControlOverviewItemResources.propTypes = {
+  resourcesData: PropTypes.arrayOf(
     PropTypes.shape({
       type: PropTypes.string,
       reference: PropTypes.string,
@@ -275,7 +275,7 @@ ControlOverviewItemInstances.propTypes = {
   ),
 };
 
-const useControlOverviewItemInstancesStyles = makeStyles((theme) => {
+const useControlOverviewItemResourcesStyles = makeStyles((theme) => {
   return {
     container: {
       marginTop: theme.spacing(2),

--- a/src/components/control-overview/control-overview.js
+++ b/src/components/control-overview/control-overview.js
@@ -7,7 +7,7 @@ import { ControlOverviewGroup } from "./control-overview-group";
 import { ControlOverviewItem } from "./control-overview-item";
 import { Message } from "../message";
 import { ControlOverviewItemDetail } from "./control-overview-item-detail";
-import { ControlOverviewItemInstances } from "./control-overview-item-instances";
+import { ControlOverviewItemResources } from "./control-overview-item-resources";
 import { ControlOverviewLoadingIndicator } from "./control-overview-loading-indicator";
 import Box from "@material-ui/core/Box";
 
@@ -15,7 +15,7 @@ export function ControlOverview({
   title,
   data,
   onRequestOfControlsData,
-  onRequestOfInstancesData,
+  onRequestOfResourcesData,
 }) {
   const theme = useTheme();
 
@@ -81,7 +81,7 @@ export function ControlOverview({
                         severity={control.severity}
                         applied={control.applied}
                         exempt={control.exempt}
-                        onChange={onRequestOfInstancesData}
+                        onChange={onRequestOfResourcesData}
                         key={control.id}
                       >
                         <ControlOverviewItemDetail
@@ -93,27 +93,27 @@ export function ControlOverview({
 
                         {(() => {
                           if (
-                            !data.instances ||
-                            !data.instances[control.id] ||
-                            data.instances[control.id] === "loading"
+                            !data.resources ||
+                            !data.resources[control.id] ||
+                            data.resources[control.id] === "loading"
                           ) {
                             return <ControlOverviewLoadingIndicator />;
                           }
 
-                          if (data.instances[control.id] === "error") {
+                          if (data.resources[control.id] === "error") {
                             return <Box paddingTop={1}>{errorMessage}</Box>;
                           }
 
-                          if (Array.isArray(data.instances[control.id])) {
-                            if (data.instances[control.id].length < 1) {
+                          if (Array.isArray(data.resources[control.id])) {
+                            if (data.resources[control.id].length < 1) {
                               return (
                                 <Box paddingTop={1}>{noIssuesMessage}</Box>
                               );
                             }
 
                             return (
-                              <ControlOverviewItemInstances
-                                instanceData={data.instances[control.id]}
+                              <ControlOverviewItemResources
+                                resourcesData={data.resources[control.id]}
                               />
                             );
                           }
@@ -177,7 +177,7 @@ ControlOverview.propTypes = {
       ])
     ),
 
-    instances: PropTypes.objectOf(
+    resources: PropTypes.objectOf(
       PropTypes.oneOfType([
         PropTypes.arrayOf(
           PropTypes.shape({
@@ -194,11 +194,11 @@ ControlOverview.propTypes = {
     ),
   }),
   /**
-   * Callback for when a user expands a control group. **Signature:** `function(groupId: int) => void`
+   * Callback for when a user expands a control group and a request is made to fetch the controls for that group. **Signature:** `function(groupId: int) => void`
    */
   onRequestOfControlsData: PropTypes.func,
   /**
-   * Callback for when a user expands a control within a given group. **Signature:** `function(controlId: int) => void`
+   * Callback for when a user expands a control within a given group and a request is made to fetch the resource data for that control. **Signature:** `function(controlId: int) => void`
    */
-  onRequestOfInstancesData: PropTypes.func,
+  onRequestOfResourcesData: PropTypes.func,
 };

--- a/src/components/control-overview/use-control-overview-controller.js
+++ b/src/components/control-overview/use-control-overview-controller.js
@@ -33,7 +33,7 @@ function reducer(state, action) {
   }
 }
 
-function useControlOverviewController(initEndpoint) {
+function useControlOverviewController(getInitalData) {
   const [state, dispatch] = useReducer(reducer);
 
   useEffect(() => {
@@ -43,21 +43,11 @@ function useControlOverviewController(initEndpoint) {
   async function initializeData() {
     dispatch({ type: "INITIALIZE", payload: "loading" });
 
-    try {
-      const response = await fetch(initEndpoint);
-      const data = await response.json();
-
-      if (!response.ok) {
-        dispatch({ type: "INITIALIZE", payload: "error" });
-      } else {
-        dispatch({ type: "INITIALIZE", payload: data });
-      }
-    } catch {
-      dispatch({ type: "INITIALIZE", payload: "error" });
-    }
+    const data = await getInitalData();
+    dispatch({ type: "INITIALIZE", payload: data });
   }
 
-  async function setControlsData(id, endpoint) {
+  async function setControlsData(id, getData) {
     const groupDataValue = state?.controls?.[id];
 
     if (
@@ -66,22 +56,12 @@ function useControlOverviewController(initEndpoint) {
     ) {
       dispatch({ type: "SET_CONTROLS_DATA", id, payload: "loading" });
 
-      try {
-        const response = await fetch(endpoint);
-        const data = await response.json();
-
-        if (!response.ok) {
-          dispatch({ type: "SET_CONTROLS_DATA", id, payload: "error" });
-        } else {
-          dispatch({ type: "SET_CONTROLS_DATA", id, payload: data });
-        }
-      } catch {
-        dispatch({ type: "SET_CONTROLS_DATA", id, payload: "error" });
-      }
+      const data = await getData();
+      dispatch({ type: "SET_CONTROLS_DATA", id, payload: data });
     }
   }
 
-  async function setResourcesData(id, endpoint) {
+  async function setResourcesData(id, getData) {
     const resourcesDataValue = state?.resources?.[id];
 
     if (
@@ -90,18 +70,8 @@ function useControlOverviewController(initEndpoint) {
     ) {
       dispatch({ type: "SET_RESOURCES_DATA", id, payload: "loading" });
 
-      try {
-        const response = await fetch(endpoint);
-        const data = await response.json();
-
-        if (!response.ok) {
-          dispatch({ type: "SET_RESOURCES_DATA", id, payload: "error" });
-        } else {
-          dispatch({ type: "SET_RESOURCES_DATA", id, payload: data });
-        }
-      } catch {
-        dispatch({ type: "SET_RESOURCES_DATA", id, payload: "error" });
-      }
+      const data = await getData();
+      dispatch({ type: "SET_RESOURCES_DATA", id, payload: data });
     }
   }
 

--- a/src/components/control-overview/use-control-overview-controller.js
+++ b/src/components/control-overview/use-control-overview-controller.js
@@ -7,10 +7,10 @@ function reducer(state, action) {
       return {
         groups: action.payload,
         controls: undefined,
-        instances: undefined,
+        resources: undefined,
       };
     }
-    case "SET_CONTROL_DATA": {
+    case "SET_CONTROLS_DATA": {
       return {
         ...state,
         controls: {
@@ -19,11 +19,11 @@ function reducer(state, action) {
         },
       };
     }
-    case "SET_INSTANCE_DATA": {
+    case "SET_RESOURCES_DATA": {
       return {
         ...state,
-        instances: {
-          ...state?.instances,
+        resources: {
+          ...state?.resources,
           [action.id]: action.payload,
         },
       };
@@ -57,55 +57,55 @@ function useControlOverviewController(initEndpoint) {
     }
   }
 
-  async function setControlData(id, endpoint) {
+  async function setControlsData(id, endpoint) {
     const groupDataValue = state?.controls?.[id];
 
     if (
       groupDataValue !== "loading" &&
       (groupDataValue === undefined || groupDataValue === "error")
     ) {
-      dispatch({ type: "SET_CONTROL_DATA", id, payload: "loading" });
+      dispatch({ type: "SET_CONTROLS_DATA", id, payload: "loading" });
 
       try {
         const response = await fetch(endpoint);
         const data = await response.json();
 
         if (!response.ok) {
-          dispatch({ type: "SET_CONTROL_DATA", id, payload: "error" });
+          dispatch({ type: "SET_CONTROLS_DATA", id, payload: "error" });
         } else {
-          dispatch({ type: "SET_CONTROL_DATA", id, payload: data });
+          dispatch({ type: "SET_CONTROLS_DATA", id, payload: data });
         }
       } catch {
-        dispatch({ type: "SET_CONTROL_DATA", id, payload: "error" });
+        dispatch({ type: "SET_CONTROLS_DATA", id, payload: "error" });
       }
     }
   }
 
-  async function setInstanceData(id, endpoint) {
-    const instanceDataValue = state?.instances?.[id];
+  async function setResourcesData(id, endpoint) {
+    const resourcesDataValue = state?.resources?.[id];
 
     if (
-      instanceDataValue !== "loading" &&
-      (instanceDataValue === undefined || instanceDataValue === "error")
+      resourcesDataValue !== "loading" &&
+      (resourcesDataValue === undefined || resourcesDataValue === "error")
     ) {
-      dispatch({ type: "SET_INSTANCE_DATA", id, payload: "loading" });
+      dispatch({ type: "SET_RESOURCES_DATA", id, payload: "loading" });
 
       try {
         const response = await fetch(endpoint);
         const data = await response.json();
 
         if (!response.ok) {
-          dispatch({ type: "SET_INSTANCE_DATA", id, payload: "error" });
+          dispatch({ type: "SET_RESOURCES_DATA", id, payload: "error" });
         } else {
-          dispatch({ type: "SET_INSTANCE_DATA", id, payload: data });
+          dispatch({ type: "SET_RESOURCES_DATA", id, payload: data });
         }
       } catch {
-        dispatch({ type: "SET_INSTANCE_DATA", id, payload: "error" });
+        dispatch({ type: "SET_RESOURCES_DATA", id, payload: "error" });
       }
     }
   }
 
-  return [state, setControlData, setInstanceData, initializeData];
+  return [state, setControlsData, setResourcesData, initializeData];
 }
 
 export { useControlOverviewController };

--- a/src/stories/control-overview/control-overview.docs.md
+++ b/src/stories/control-overview/control-overview.docs.md
@@ -1,15 +1,15 @@
-The `ControlOverview` is a presentational component, that is complimented with an optional controller `useControlOverviewController`, which can be used for state management and asynchronous retrival of group, control and instances data.
+The `ControlOverview` is a presentational component, that is complimented with an optional controller `useControlOverviewController`, which can be used for state management of group, control and resources data.
 
 ## Importing the component and controller
 
 ```javascript
 import {
   ControlOverview,
-  useControlOverviewController
+  useControlOverviewController,
 } from "@/components/control-overview";
 ```
 
-## Providing data to thecomponent
+## Providing data to the component
 
 The data object used to populate the component is intented to work as a relational table of sub-data, with no data set, the component defaults to a loading state.
 
@@ -17,7 +17,7 @@ The top level data keys are:
 
 - `groups` : Used to populate control groupings within the UI; the data should be an array of groups or a string, to indicate either an error or loading status. Setting the data to an empty array indicates there are no issues for the component to display.
 - `controls` : Used to store data for controls; the data should be an object of arrays or a string, to indicate either an error or loading status. The object key should be equal to the group id the data relates to; setting the data to an empty array indicates there are no issues for the specific control.
-- `instances` Used to store instance data for a specific control; the data should be an object of arrays or a string, to indicate either an error or loading status. The object key should be equal to the control id the data relates to; setting the data to an empty array indicates there are no instances for the specific control.
+- `resources` Used to store resource data for a specific control; the data should be an object of arrays or a string, to indicate either an error or loading status. The object key should be equal to the control id the data relates to; setting the data to an empty array indicates there are no resources for the specific control.
 
 ## Using the optional controller
 
@@ -25,13 +25,15 @@ The component comes with an optional controller as a custom React hook, that can
 
 ### Initialising
 
-The controller hook accepts one parameter (`string`), to act as an API endpoint to fetch the initial group data. The API should return an empty array or array of objects, equal to the following schema:
+The controller hook accepts one parameter (`function`), to act as an mechanism fetch the initial group data. The function should return data equal to the `groups` key within the `data` prop:
 
 ```javascript
-{
-  id: number,
-  title: string
-}
+[
+  {
+    id: number,
+    title: string
+  }
+] | 'error',
 ```
 
 ### Return values
@@ -42,66 +44,59 @@ The controller hook will return an array containing:
 
 An object of the current state, used to feed the `data` prop of the `ControlOverview` component.
 
-If the response of the API call is successfull, any subsequent requests to fetch data will be bypassed, to reduce server load and improve performance.
+#### Controls data setter
 
-If the response of the API call results in an error, subsequent requests to fetch data will be attempted until a successful response is resolved.
+A function to set the contol data that accepts two parameters, group id (`int`) and an asynchronous function used to fetch control data specific to the requested group.
 
-The API should return an empty array or array of objects, equal to the following schema:
+This callback to fetch the control data will not be fired if control data already exists for a given group id.
 
-```javascript
-{
-  id: number,
-  title: string
-}
-```
-
-#### Control data setter
-
-A function to set the contol data that accepts two parameters, group id (`int`) and an API endpoint (`string`) that is used to fetch control data specific to the requested group.
-
-If the response of the API call is successfull, any subsequent requests to fetch data will be bypassed, to reduce server load and improve performance.
-
-If the response of the API call results in an error, subsequent requests to fetch data will be attempted until a successful response is resolved.
-
-The API should return an empty array or array of objects, equal to the following schema:
+The function should return data equal to the `controls` key within the `data` prop:
 
 ```javascript
-{
-  id: number,
-  name: string,
-  severity: 'Low' | 'Medium' | 'High',
-  applied: number,
-  exempt: number,
-  control: {
+[
+  {
+    id: number,
     name: string,
-    url: string
+    severity: "Low" | "Medium" | "High",
+    applied: number,
+    exempt: number,
+    control: {
+      name: string,
+      url: string,
+    },
+    frameworks: [
+      {
+        name: string,
+        url: string,
+      },
+    ],
+    controlType: string,
+    lifecycle: string,
   },
-  frameworks: [{
-    name: string,
-    url: string
-  }],
-  controlType: string,
-  lifecycle: string
-}
+] | "error";
 ```
 
-#### Instance data setter
+#### Resources data setter
 
-A function to set the instance data that accepts two parameters, control id (`int`) and an API endpoint (`string`) that is used to fetch instance data specific to the requested control.
+A function to set the resources data that accepts two parameters, control id (`int`) and an asynchronous function used to fetch resources data specific to the requested control id.
 
-If the response of the API call is successfull, any subsequent requests to fetch data will be bypassed, to reduce server load and improve performance.
+This callback to fetch the resources data will not be fired if resources data already exists for a given control id.
 
-If the response of the API call results in an error, subsequent requests to fetch data will be attempted until a successful response is resolved.
-
-The API should return an empty array or array of objects, equal to the following schema:
+The function should return data equal to the `resources` key within the `data` prop:
 
 ```javascript
-{
-  id: number,
-  type: string,
-  reference: string,
-  environment: string,
-  lastSeen: string,
-  status: 'Monitoring' | 'Non-Compliant' | 'Exempt'
-}
+[
+  {
+    id: number,
+    type: string,
+    reference: string,
+    environment: string,
+    lastSeen: string,
+    status: "Monitoring" | "Non-Compliant" | "Exempt",
+  },
+] | "error";
 ```
+
+#### Initialiser
+
+A function to reset the component data back to it's intial state and re-fetch the data. Internally this calls the same function passed when invoking the hook.

--- a/src/stories/control-overview/control-overview.stories.js
+++ b/src/stories/control-overview/control-overview.stories.js
@@ -44,20 +44,54 @@ function Default() {
     state,
     setControlsData,
     setResourcesData,
-  ] = useControlOverviewController("https://testapi.dev/quality-models");
+  ] = useControlOverviewController(async () => {
+    try {
+      const response = await fetch(`https://testapi.dev/quality-models`);
 
-  const handleOnRequestOfControlsData = async (id) => {
-    setControlsData(
-      id,
-      `https://testapi.dev/applications/1/control-overviews?qualityModelId=${id}`
-    );
+      if (response.ok) {
+        return await response.json();
+      }
+
+      throw new Error();
+    } catch (error) {
+      return "error";
+    }
+  });
+
+  const handleOnRequestOfControlsData = (id) => {
+    setControlsData(id, async () => {
+      try {
+        const response = await fetch(
+          `https://testapi.dev/applications/1/control-overviews?qualityModelId=${id}`
+        );
+
+        if (response.ok) {
+          return await response.json();
+        }
+
+        throw new Error();
+      } catch (error) {
+        return "error";
+      }
+    });
   };
 
-  const handleOnRequestOfResourcesData = async (id) => {
-    setResourcesData(
-      id,
-      `https://testapi.dev/applications/1/monitored-resources?technicalControlId=${id}`
-    );
+  const handleOnRequestOfResourcesData = (id) => {
+    setResourcesData(id, async () => {
+      try {
+        const response = await fetch(
+          `https://testapi.dev/applications/1/monitored-resources?technicalControlId=${id}`
+        );
+
+        if (response.ok) {
+          return await response.json();
+        }
+
+        throw new Error();
+      } catch (error) {
+        return "error";
+      }
+    });
   };
 
   return (

--- a/src/stories/control-overview/control-overview.stories.js
+++ b/src/stories/control-overview/control-overview.stories.js
@@ -40,19 +40,21 @@ const config = {
 };
 
 function Default() {
-  const [state, setControlData, setInstanceData] = useControlOverviewController(
-    "https://testapi.dev/quality-models"
-  );
+  const [
+    state,
+    setControlsData,
+    setResourcesData,
+  ] = useControlOverviewController("https://testapi.dev/quality-models");
 
   const handleOnRequestOfControlsData = async (id) => {
-    setControlData(
+    setControlsData(
       id,
       `https://testapi.dev/applications/1/control-overviews?qualityModelId=${id}`
     );
   };
 
-  const handleOnRequestOfInstancesData = async (id) => {
-    setInstanceData(
+  const handleOnRequestOfResourcesData = async (id) => {
+    setResourcesData(
       id,
       `https://testapi.dev/applications/1/monitored-resources?technicalControlId=${id}`
     );
@@ -63,7 +65,7 @@ function Default() {
       title="Control Overview"
       data={state}
       onRequestOfControlsData={handleOnRequestOfControlsData}
-      onRequestOfInstancesData={handleOnRequestOfInstancesData}
+      onRequestOfResourcesData={handleOnRequestOfResourcesData}
     />
   );
 }
@@ -72,7 +74,7 @@ function WithNoIssues() {
   const data = {
     groups: [],
     controls: undefined,
-    instances: undefined,
+    resources: undefined,
   };
 
   return (
@@ -80,7 +82,7 @@ function WithNoIssues() {
       title="Control Overview"
       data={data}
       onRequestOfControlsData={(id) => console.log("group id", id)}
-      onRequestOfInstancesData={(id) => console.log("control id", id)}
+      onRequestOfResourcesData={(id) => console.log("control id", id)}
     />
   );
 }
@@ -89,7 +91,7 @@ function WithError() {
   const data = {
     groups: "error",
     controls: undefined,
-    instances: undefined,
+    resources: undefined,
   };
 
   return (
@@ -97,7 +99,7 @@ function WithError() {
       title="Control Overview"
       data={data}
       onRequestOfControlsData={(id) => console.log("group id", id)}
-      onRequestOfInstancesData={(id) => console.log("control id", id)}
+      onRequestOfResourcesData={(id) => console.log("control id", id)}
     />
   );
 }

--- a/src/stories/control-overview/mocks/data.js
+++ b/src/stories/control-overview/mocks/data.js
@@ -90,7 +90,7 @@ export const controls = {
   2: [],
 };
 
-export const instances = {
+export const resources = {
   1: [
     {
       id: 1,

--- a/src/stories/control-overview/mocks/handlers.js
+++ b/src/stories/control-overview/mocks/handlers.js
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 import { groups, controls, instances } from "./data";
 
-const delay = process.env.NODE_ENV === "test" ? 0 : 2000;
+const delay = process.env.NODE_ENV === "test" ? 0 : 500;
 
 export const handlers = [
   rest.get("https://testapi.dev/quality-models", (req, res, ctx) => {

--- a/src/stories/control-overview/mocks/handlers.js
+++ b/src/stories/control-overview/mocks/handlers.js
@@ -1,5 +1,5 @@
 import { rest } from "msw";
-import { groups, controls, instances } from "./data";
+import { groups, controls, resources } from "./data";
 
 const delay = process.env.NODE_ENV === "test" ? 0 : 500;
 
@@ -36,7 +36,7 @@ export const handlers = [
         );
       }
 
-      return res(ctx.delay(delay), ctx.json(instances[technicalControlId]));
+      return res(ctx.delay(delay), ctx.json(resources[technicalControlId]));
     }
   ),
 ];


### PR DESCRIPTION
Changes:

- All occurrences of "instances" to "resources" within `ControlOverview` component
- `useControlOverviewController` to delegate the fetching of data via passed callback param

closes airwalk-digital/airview-issues#95