### PR TITLE
Fix GH pages storybook errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/storybook-static
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:coverage": "npm test -- --coverage --watchAll=false --maxWorkers=50%",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -s public -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -s public",
     "lint-js": "eslint './src/**/*.{js, jsx}'",
     "lint-js:fix": "npm run lint-js -- --fix",
     "format": "prettier --check './src/'",


### PR DESCRIPTION
Adds required storybook CLI flag to build script `npm run build-storybook` to point required public directory (for assets etc).

fixes airwalk-digital/airview-issues#107
fixes airwalk-digital/airview-issues#106