### PR TITLE
Fix content editor attempt to always use ado

### DIFF
--- a/src/lib/markdown-backend-config.js
+++ b/src/lib/markdown-backend-config.js
@@ -22,8 +22,10 @@ export function getContentBackendConfig() {
   switch (process.env.REACT_APP_CONTENT_BACKEND) {
     case "github":
       client = new GithubClient(backendClientConfig);
+      break;
     case "ado":
       client = new AdoClient(backendClientConfig);
+      break;
   }
 
   return { initialState, client };


### PR DESCRIPTION
Fix content editor attempt to always use ado

Caused by not breaking from switch.