### PR TITLE
Add ControlOverview supporting evidence modal

### DIFF
--- a/src/api-mock/data.js
+++ b/src/api-mock/data.js
@@ -109,6 +109,7 @@ export const resources = {
       lastSeen: dayjs().subtract(1, "day").toISOString(),
       status: "Non-Compliant",
       pending: false,
+      evidence: `Markdown Content`,
     },
     {
       id: 3,

--- a/src/components/control-overview/control-overview-item-resources.js
+++ b/src/components/control-overview/control-overview-item-resources.js
@@ -23,12 +23,14 @@ import Box from "@material-ui/core/Box";
 import SettingsIcon from "@material-ui/icons/Settings";
 import CheckIcon from "@material-ui/icons/Check";
 import ClearIcon from "@material-ui/icons/Clear";
+import InfoIcon from "@material-ui/icons/Info";
 import clsx from "clsx";
 import dayjs from "dayjs";
 
 export function ControlOverviewItemResources({
   resourcesData,
   onManageResourceClick,
+  onViewResourceEvidence,
 }) {
   const classes = useControlOverviewItemResourcesStyles();
 
@@ -238,6 +240,7 @@ export function ControlOverviewItemResources({
               <TableCell>Status</TableCell>
               <TableCell>Pending</TableCell>
               <TableCell></TableCell>
+              <TableCell></TableCell>
             </TableRow>
           </TableHead>
 
@@ -286,6 +289,24 @@ export function ControlOverviewItemResources({
                       "-"
                     )}
                   </TableCell>
+                  <TableCell align="center">
+                    {resource?.evidence ? (
+                      <Tooltip title={"View Evidence"}>
+                        <span>
+                          <IconButton
+                            aria-label="View Evidence"
+                            color="primary"
+                            size="small"
+                            onClick={() => onViewResourceEvidence(resource.id)}
+                          >
+                            <InfoIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
                 </TableRow>
               );
             })}
@@ -308,6 +329,7 @@ ControlOverviewItemResources.propTypes = {
     })
   ),
   onManageResourceClick: PropTypes.func.isRequired,
+  onViewResourceEvidence: PropTypes.func.isRequired,
 };
 
 const useControlOverviewItemResourcesStyles = makeStyles((theme) => {

--- a/src/components/control-overview/control-overview-resource-evidence-viewer.js
+++ b/src/components/control-overview/control-overview-resource-evidence-viewer.js
@@ -1,0 +1,55 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from "@material-ui/core";
+import { MarkdownContent } from "../markdown-content";
+
+export function ControlOverviewResourceEvidenceViewer({
+  open,
+  onClose,
+  resourceEvidenceData,
+}) {
+  return (
+    <Dialog
+      aria-labelledby="control-overview-resource-evidence-viewer"
+      open={open}
+      maxWidth="lg"
+      fullWidth
+      disableEscapeKeyDown
+    >
+      <DialogTitle id="control-overview-resource-evidence-viewer">
+        Resource Supporting Evidence
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <MarkdownContent
+          defaultValue={resourceEvidenceData}
+          readOnly={true}
+          loading={false}
+        />
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          color="primary"
+          variant="contained"
+          disableElevation
+        >
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+ControlOverviewResourceEvidenceViewer.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  resourceEvidenceData: PropTypes.string,
+};

--- a/src/components/control-overview/control-overview.js
+++ b/src/components/control-overview/control-overview.js
@@ -12,6 +12,7 @@ import { ControlOverviewItemDetail } from "./control-overview-item-detail";
 import { ControlOverviewItemResources } from "./control-overview-item-resources";
 import { ControlOverviewLoadingIndicator } from "./control-overview-loading-indicator";
 import { ControlOverviewResourceManager } from "./control-overview-resource-manager";
+import { ControlOverviewResourceEvidenceViewer } from "./control-overview-resource-evidence-viewer";
 
 export function ControlOverview({
   loading,
@@ -30,8 +31,18 @@ export function ControlOverview({
     resourceId: null,
   };
 
+  const initialResourceEvidenceStatus = {
+    open: false,
+    controlId: null,
+    resourceId: null,
+  };
+
   const [exemptionManagerStatus, setExemptionManagerStatus] = useState({
     ...initialResourceManagerStatus,
+  });
+
+  const [resourceEvidenceStatus, setResourceEvidenceStatus] = useState({
+    ...initialResourceEvidenceStatus,
   });
 
   const errorMessageFeedback = (
@@ -85,6 +96,31 @@ export function ControlOverview({
 
     return resourcesData;
   }, [data, exemptionManagerStatus]);
+
+  const handleOnViewResourceEvidenceClick = (controlId, resourceId) => {
+    console.log("controlId:", controlId);
+    console.log("resourceId:", resourceId);
+
+    setResourceEvidenceStatus({
+      open: true,
+      controlId,
+      resourceId,
+    });
+  };
+
+  const handleOnViewResourceEvidenceClose = () => {
+    setResourceEvidenceStatus({ ...initialResourceEvidenceStatus });
+  };
+
+  const resourceEvidenceData = useMemo(() => {
+    if (!resourceEvidenceStatus.open) return null;
+
+    return (
+      data.resources[resourceEvidenceStatus.controlId].filter(
+        (resource) => resource.id === resourceEvidenceStatus.resourceId
+      )[0].evidence ?? null
+    );
+  }, [data, resourceEvidenceStatus]);
 
   if (loading) {
     return <Skeleton variant="rect" width="100%" height={200} />;
@@ -212,6 +248,12 @@ export function ControlOverview({
                                       resourceId
                                     );
                                   }}
+                                  onViewResourceEvidence={(resourceId) => {
+                                    handleOnViewResourceEvidenceClick(
+                                      control.id,
+                                      resourceId
+                                    );
+                                  }}
                                 />
                               );
                             }
@@ -225,11 +267,18 @@ export function ControlOverview({
             );
           })}
         </Paper>
+
         <ControlOverviewResourceManager
           open={exemptionManagerStatus.open}
           onClose={handleOnResourceManagerClose}
           resourceData={resourceManagerData}
           {...{ onResourceExemptionDelete, onResourceExemptionSave }}
+        />
+
+        <ControlOverviewResourceEvidenceViewer
+          open={resourceEvidenceStatus.open}
+          onClose={handleOnViewResourceEvidenceClose}
+          resourceEvidenceData={resourceEvidenceData}
         />
       </React.Fragment>
     );

--- a/src/components/control-overview/control-overview.js
+++ b/src/components/control-overview/control-overview.js
@@ -98,9 +98,6 @@ export function ControlOverview({
   }, [data, exemptionManagerStatus]);
 
   const handleOnViewResourceEvidenceClick = (controlId, resourceId) => {
-    console.log("controlId:", controlId);
-    console.log("resourceId:", resourceId);
-
     setResourceEvidenceStatus({
       open: true,
       controlId,

--- a/src/pages/applications-page/applications-page.js
+++ b/src/pages/applications-page/applications-page.js
@@ -130,27 +130,29 @@ export function ApplicationsPage() {
       console.error(error);
     }
   };
-  const [controlOverviewState, setControlsData, setResourcesData] =
-    useControlOverviewController(async () => {
-      if (state.applicationId == undefined) {
-        return [];
-      }
-      const models = JSON.parse(
-        await (
-          await apiService(
-            `/api/applications/${state.applicationId}/quality-models`
-          )
-        ).data.text()
-      );
-      return models.map((item, index) => {
-        return {
-          id: index,
-          title:
-            item.name.charAt(0).toUpperCase() +
-            item.name.slice(1).toLowerCase(),
-        };
-      });
-    }, state.applicationId);
+  const [
+    controlOverviewState,
+    setControlsData,
+    setResourcesData,
+  ] = useControlOverviewController(async () => {
+    if (state.applicationId == undefined) {
+      return [];
+    }
+    const models = JSON.parse(
+      await (
+        await apiService(
+          `/api/applications/${state.applicationId}/quality-models`
+        )
+      ).data.text()
+    );
+    return models.map((item, index) => {
+      return {
+        id: index,
+        title:
+          item.name.charAt(0).toUpperCase() + item.name.slice(1).toLowerCase(),
+      };
+    });
+  }, state.applicationId);
 
   const handleOnRequestOfControlsData = (id) => {
     setControlsData(id, async () => {

--- a/src/stories/control-overview/control-overview.docs.md
+++ b/src/stories/control-overview/control-overview.docs.md
@@ -98,7 +98,8 @@ The function should return data equal to the `resources` key within the `data` p
       ticket: string,
       expires: string // ISO Date String
       resources: [string]
-    }
+    },
+    evidence: string // Markdown
   },
 ] | "error";
 ```

--- a/src/tests/control-overview.test.js
+++ b/src/tests/control-overview.test.js
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, screen, within, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  within,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import { composeStories } from "@storybook/testing-react";
 import * as stories from "../stories/control-overview/control-overview.stories";
 import userEvent from "@testing-library/user-event";
@@ -143,5 +149,28 @@ describe("ControlOverview", () => {
     await waitFor(() => expect(manageExemptionDialog).not.toBeInTheDocument());
 
     // To do, assert onResourceExemptionDelete was called
+  });
+
+  test("a user can toggle the visibility of a resource supporting evidence", async () => {
+    const viewEvidenceBtn = await screen.findByRole("button", {
+      name: /view evidence/i,
+    });
+
+    // Click the view evidence button
+    userEvent.click(viewEvidenceBtn);
+
+    // Wait for the dialog to become visible
+    const evidenceDialog = await screen.findByRole("dialog");
+
+    // It should contain the correct content
+    expect(
+      within(evidenceDialog).getByText(/markdown content/i)
+    ).toBeInTheDocument();
+
+    // Click the close dialog button
+    userEvent.click(within(evidenceDialog).getByRole("button"));
+
+    // The dialog should not remain visible
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
   });
 });


### PR DESCRIPTION
Adds a modal popup to the ControlOverview resources table to allow the viewing of evidence documents.

closes airwalk-digital/airview-issues#139